### PR TITLE
Fix warning

### DIFF
--- a/prefPane/id-updater-helper.m
+++ b/prefPane/id-updater-helper.m
@@ -80,7 +80,7 @@ int main(int argc, const char * argv[])
         }
 
         NSDateComponents *components = [[NSCalendar currentCalendar]
-                                        components:NSHourCalendarUnit|NSMinuteCalendarUnit|NSWeekdayCalendarUnit|NSDayCalendarUnit
+                                        components:NSCalendarUnitHour|NSCalendarUnitMinute|NSCalendarUnitWeekday|NSCalendarUnitDay
                                         fromDate:[NSDate date]];
         NSNumber *hour = [NSNumber numberWithInteger:[components hour]];
         NSNumber *minute = [NSNumber numberWithInteger:[components minute]];


### PR DESCRIPTION
NSHourCalendarUnit, NSMinuteCalendarUnit, NSWeekdayCalendarUnit, NSDayCalendarUnit are deprecated

Signed-off-by: Raul Metsma <raul@metsma.ee>